### PR TITLE
fix: 💬 now no errors when doing npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "author": "Albert Gao <albertgaohy@gmail.com>",
   "repository": {
-    "url": "git+https://github.com/Albert-Gao/auto-zustand-selectors-hook",
+    "url": "git+https://github.com/Albert-Gao/auto-zustand-selectors-hook.git",
     "type": "git"
   },
   "bugs": {


### PR DESCRIPTION
to fix this when publishing:
![image](https://github.com/Albert-Gao/auto-zustand-selectors-hook/assets/18282328/230b275a-e750-464c-b9ea-54edf89e4846)
