### PR TITLE
Refactor of selector generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-zustand-selectors-hook",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "keywords": [],
   "description": "",
   "main": "dist/index.min.js",

--- a/src/createSelectorFunctions.ts
+++ b/src/createSelectorFunctions.ts
@@ -15,11 +15,9 @@ export function createSelectorFunctions<StateType extends object>(
 
   Object.keys(storeIn.getState()).forEach((key) => {
     const selector = (state: StateType) => state[key as keyof StateType];
-    storeIn.use[key] = () => {
-      return typeof storeIn === 'function'
-        ? storeIn(selector)
-        : useStore(storeIn, selector as any);
-    };
+    storeIn.use[key] = typeof storeIn === 'function'
+      ? () => storeIn(selector)
+      : () => useStore(storeIn, selector as any);
   });
 
   return store as UseBoundStore<StoreApi<StateType>> &

--- a/src/createSelectorHooks.ts
+++ b/src/createSelectorHooks.ts
@@ -15,11 +15,9 @@ export function createSelectorHooks<StateType extends object>(
 
   Object.keys(storeIn.getState()).forEach((key) => {
     const selector = (state: StateType) => state[key as keyof StateType];
-    storeIn[`use${capitalize(key)}`] = () => {
-      return typeof storeIn === 'function'
-        ? storeIn(selector)
-        : useStore(storeIn, selector as any);
-    };
+    storeIn[`use${capitalize(key)}`] = typeof storeIn === 'function'
+      ? () => storeIn(selector)
+      : () => useStore(storeIn, selector as any);
   });
 
   return storeIn as UseBoundStore<StoreApi<StateType>> &


### PR DESCRIPTION
Previously, selectors were unnecessarly re-generated on every call to store. Now appropriate selectors generated only once. Performance improvement.