### PR TITLE
Fix NonUllable field hooks

### DIFF
--- a/src/createSelectorFunctions.ts
+++ b/src/createSelectorFunctions.ts
@@ -3,7 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 export interface ZustandFuncSelectors<StateType> {
   use: {
-    [key in keyof StateType]: () => StateType[key];
+    [key in NonNullable<keyof StateType>]: () => StateType[key];
   };
 }
 

--- a/src/createSelectorHooks.ts
+++ b/src/createSelectorHooks.ts
@@ -2,7 +2,7 @@ import { type StoreApi, type UseBoundStore, useStore } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 
 export type ZustandHookSelectors<StateType> = {
-  [Key in keyof StateType as `use${Capitalize<
+  [Key in NonNullable<keyof StateType> as `use${Capitalize<
     string & Key
   >}`]: () => StateType[Key];
 };


### PR DESCRIPTION
When you have states with nullable or undefined fields, the generated hooks require you to use `!`. This is not necessary, as the field will always exist.

```ts
import {createSelectorFunctions} from 'auto-zustand-selectors-hook';
import {Customer} from '@/api/schemas/customer';
import {create} from 'zustand';

type CustomerStore = {
  selectedCustomer?: Customer;
  selectCustomer: (selectedCustomer: Customer) => void;
};

const useCustomerStoreBase = create<CustomerStore>()(set => ({
  selectedCustomer: undefined,
  selectCustomer: selectedCustomer => set({selectedCustomer}),
}));

export const useCustomerStore = createSelectorFunctions(useCustomerStoreBase);
```

Actual usage:
```ts
useCustomerStore.use.selectedCustomer!()
``` 

Expected usage:
```ts
useCustomerStore.use.selectedCustomer()
```

<img width="719" alt="image" src="https://github.com/user-attachments/assets/2d1a11b8-ef1b-4014-9c72-70d50e967dd1" />


## Summary by Sourcery

Bug Fixes:
- Fix the issue with generated hooks requiring non-null assertion for nullable or undefined fields by using NonNullable type.