### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-zustand-selectors-hook",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [],
   "description": "",
   "main": "dist/index.min.js",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bumped version to 3.0.1.